### PR TITLE
feat(python): support Edge.js with V8

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4047,7 +4047,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
 dependencies = [
  "fastrand",
- "getrandom 0.4.3",
+ "getrandom 0.3.4",
  "once_cell",
  "rustix",
  "windows-sys 0.61.2",
@@ -4656,9 +4656,8 @@ checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 [[package]]
 name = "virtual-fs"
 version = "0.704.0"
-source = "git+https://github.com/wasmerio/wasmer.git?rev=6a3731fa465efb32f4d9e9406f867a4e7aef497a#6a3731fa465efb32f4d9e9406f867a4e7aef497a"
+source = "git+https://github.com/wasmerio/wasmer.git?rev=06f1e8dca774f313d1e4a86e7bd9324a8fd0f489#06f1e8dca774f313d1e4a86e7bd9324a8fd0f489"
 dependencies = [
- "anyhow",
  "async-trait",
  "bytes",
  "dashmap",
@@ -4668,7 +4667,6 @@ dependencies = [
  "fs_extra",
  "futures",
  "getrandom 0.4.3",
- "indexmap",
  "libc",
  "pin-project-lite",
  "replace_with",
@@ -4686,7 +4684,7 @@ dependencies = [
 [[package]]
 name = "virtual-mio"
 version = "0.704.0"
-source = "git+https://github.com/wasmerio/wasmer.git?rev=6a3731fa465efb32f4d9e9406f867a4e7aef497a#6a3731fa465efb32f4d9e9406f867a4e7aef497a"
+source = "git+https://github.com/wasmerio/wasmer.git?rev=06f1e8dca774f313d1e4a86e7bd9324a8fd0f489#06f1e8dca774f313d1e4a86e7bd9324a8fd0f489"
 dependencies = [
  "async-trait",
  "bytes",
@@ -4702,7 +4700,7 @@ dependencies = [
 [[package]]
 name = "virtual-net"
 version = "0.704.0"
-source = "git+https://github.com/wasmerio/wasmer.git?rev=6a3731fa465efb32f4d9e9406f867a4e7aef497a#6a3731fa465efb32f4d9e9406f867a4e7aef497a"
+source = "git+https://github.com/wasmerio/wasmer.git?rev=06f1e8dca774f313d1e4a86e7bd9324a8fd0f489#06f1e8dca774f313d1e4a86e7bd9324a8fd0f489"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4978,7 +4976,7 @@ dependencies = [
 [[package]]
 name = "wasmer"
 version = "7.4.0"
-source = "git+https://github.com/wasmerio/wasmer.git?rev=6a3731fa465efb32f4d9e9406f867a4e7aef497a#6a3731fa465efb32f4d9e9406f867a4e7aef497a"
+source = "git+https://github.com/wasmerio/wasmer.git?rev=06f1e8dca774f313d1e4a86e7bd9324a8fd0f489#06f1e8dca774f313d1e4a86e7bd9324a8fd0f489"
 dependencies = [
  "bindgen",
  "bytes",
@@ -5016,7 +5014,7 @@ dependencies = [
 [[package]]
 name = "wasmer-c-api-imports"
 version = "7.4.0"
-source = "git+https://github.com/wasmerio/wasmer.git?rev=6a3731fa465efb32f4d9e9406f867a4e7aef497a#6a3731fa465efb32f4d9e9406f867a4e7aef497a"
+source = "git+https://github.com/wasmerio/wasmer.git?rev=06f1e8dca774f313d1e4a86e7bd9324a8fd0f489#06f1e8dca774f313d1e4a86e7bd9324a8fd0f489"
 dependencies = [
  "anyhow",
  "bytes",
@@ -5029,7 +5027,7 @@ dependencies = [
 [[package]]
 name = "wasmer-compiler"
 version = "7.4.0"
-source = "git+https://github.com/wasmerio/wasmer.git?rev=6a3731fa465efb32f4d9e9406f867a4e7aef497a#6a3731fa465efb32f4d9e9406f867a4e7aef497a"
+source = "git+https://github.com/wasmerio/wasmer.git?rev=06f1e8dca774f313d1e4a86e7bd9324a8fd0f489#06f1e8dca774f313d1e4a86e7bd9324a8fd0f489"
 dependencies = [
  "addr2line 0.27.1",
  "backtrace",
@@ -5068,7 +5066,7 @@ dependencies = [
 [[package]]
 name = "wasmer-compiler-cranelift"
 version = "7.4.0"
-source = "git+https://github.com/wasmerio/wasmer.git?rev=6a3731fa465efb32f4d9e9406f867a4e7aef497a#6a3731fa465efb32f4d9e9406f867a4e7aef497a"
+source = "git+https://github.com/wasmerio/wasmer.git?rev=06f1e8dca774f313d1e4a86e7bd9324a8fd0f489#06f1e8dca774f313d1e4a86e7bd9324a8fd0f489"
 dependencies = [
  "cranelift-codegen",
  "cranelift-entity",
@@ -5090,7 +5088,7 @@ dependencies = [
 [[package]]
 name = "wasmer-config"
 version = "0.704.0"
-source = "git+https://github.com/wasmerio/wasmer.git?rev=6a3731fa465efb32f4d9e9406f867a4e7aef497a#6a3731fa465efb32f4d9e9406f867a4e7aef497a"
+source = "git+https://github.com/wasmerio/wasmer.git?rev=06f1e8dca774f313d1e4a86e7bd9324a8fd0f489#06f1e8dca774f313d1e4a86e7bd9324a8fd0f489"
 dependencies = [
  "anyhow",
  "bytesize",
@@ -5112,7 +5110,7 @@ dependencies = [
 [[package]]
 name = "wasmer-derive"
 version = "7.4.0"
-source = "git+https://github.com/wasmerio/wasmer.git?rev=6a3731fa465efb32f4d9e9406f867a4e7aef497a#6a3731fa465efb32f4d9e9406f867a4e7aef497a"
+source = "git+https://github.com/wasmerio/wasmer.git?rev=06f1e8dca774f313d1e4a86e7bd9324a8fd0f489#06f1e8dca774f313d1e4a86e7bd9324a8fd0f489"
 dependencies = [
  "proc-macro-error2",
  "proc-macro2",
@@ -5123,7 +5121,7 @@ dependencies = [
 [[package]]
 name = "wasmer-journal"
 version = "0.704.0"
-source = "git+https://github.com/wasmerio/wasmer.git?rev=6a3731fa465efb32f4d9e9406f867a4e7aef497a#6a3731fa465efb32f4d9e9406f867a4e7aef497a"
+source = "git+https://github.com/wasmerio/wasmer.git?rev=06f1e8dca774f313d1e4a86e7bd9324a8fd0f489#06f1e8dca774f313d1e4a86e7bd9324a8fd0f489"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -5150,7 +5148,7 @@ dependencies = [
 [[package]]
 name = "wasmer-napi"
 version = "0.704.0"
-source = "git+https://github.com/wasmerio/wasmer.git?rev=6a3731fa465efb32f4d9e9406f867a4e7aef497a#6a3731fa465efb32f4d9e9406f867a4e7aef497a"
+source = "git+https://github.com/wasmerio/wasmer.git?rev=06f1e8dca774f313d1e4a86e7bd9324a8fd0f489#06f1e8dca774f313d1e4a86e7bd9324a8fd0f489"
 dependencies = [
  "anyhow",
  "cc",
@@ -5169,7 +5167,7 @@ dependencies = [
 [[package]]
 name = "wasmer-package"
 version = "0.704.0"
-source = "git+https://github.com/wasmerio/wasmer.git?rev=6a3731fa465efb32f4d9e9406f867a4e7aef497a#6a3731fa465efb32f4d9e9406f867a4e7aef497a"
+source = "git+https://github.com/wasmerio/wasmer.git?rev=06f1e8dca774f313d1e4a86e7bd9324a8fd0f489#06f1e8dca774f313d1e4a86e7bd9324a8fd0f489"
 dependencies = [
  "anyhow",
  "bytes",
@@ -5277,7 +5275,7 @@ dependencies = [
 [[package]]
 name = "wasmer-types"
 version = "7.4.0"
-source = "git+https://github.com/wasmerio/wasmer.git?rev=6a3731fa465efb32f4d9e9406f867a4e7aef497a#6a3731fa465efb32f4d9e9406f867a4e7aef497a"
+source = "git+https://github.com/wasmerio/wasmer.git?rev=06f1e8dca774f313d1e4a86e7bd9324a8fd0f489#06f1e8dca774f313d1e4a86e7bd9324a8fd0f489"
 dependencies = [
  "bytecheck",
  "crc32fast",
@@ -5299,7 +5297,7 @@ dependencies = [
 [[package]]
 name = "wasmer-vm"
 version = "7.4.0"
-source = "git+https://github.com/wasmerio/wasmer.git?rev=6a3731fa465efb32f4d9e9406f867a4e7aef497a#6a3731fa465efb32f4d9e9406f867a4e7aef497a"
+source = "git+https://github.com/wasmerio/wasmer.git?rev=06f1e8dca774f313d1e4a86e7bd9324a8fd0f489#06f1e8dca774f313d1e4a86e7bd9324a8fd0f489"
 dependencies = [
  "backtrace",
  "bytesize",
@@ -5328,7 +5326,7 @@ dependencies = [
 [[package]]
 name = "wasmer-wasix"
 version = "0.704.0"
-source = "git+https://github.com/wasmerio/wasmer.git?rev=6a3731fa465efb32f4d9e9406f867a4e7aef497a#6a3731fa465efb32f4d9e9406f867a4e7aef497a"
+source = "git+https://github.com/wasmerio/wasmer.git?rev=06f1e8dca774f313d1e4a86e7bd9324a8fd0f489#06f1e8dca774f313d1e4a86e7bd9324a8fd0f489"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -5410,7 +5408,7 @@ dependencies = [
 [[package]]
 name = "wasmer-wasix-types"
 version = "0.704.0"
-source = "git+https://github.com/wasmerio/wasmer.git?rev=6a3731fa465efb32f4d9e9406f867a4e7aef497a#6a3731fa465efb32f4d9e9406f867a4e7aef497a"
+source = "git+https://github.com/wasmerio/wasmer.git?rev=06f1e8dca774f313d1e4a86e7bd9324a8fd0f489#06f1e8dca774f313d1e4a86e7bd9324a8fd0f489"
 dependencies = [
  "anyhow",
  "bitflags 2.13.1",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4656,7 +4656,7 @@ checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 [[package]]
 name = "virtual-fs"
 version = "0.704.0"
-source = "git+https://github.com/wasmerio/wasmer.git?rev=06f1e8dca774f313d1e4a86e7bd9324a8fd0f489#06f1e8dca774f313d1e4a86e7bd9324a8fd0f489"
+source = "git+https://github.com/wasmerio/wasmer.git?rev=e4101323e18d07c7f8367f1de1cec7cd5eff1b74#e4101323e18d07c7f8367f1de1cec7cd5eff1b74"
 dependencies = [
  "async-trait",
  "bytes",
@@ -4684,7 +4684,7 @@ dependencies = [
 [[package]]
 name = "virtual-mio"
 version = "0.704.0"
-source = "git+https://github.com/wasmerio/wasmer.git?rev=06f1e8dca774f313d1e4a86e7bd9324a8fd0f489#06f1e8dca774f313d1e4a86e7bd9324a8fd0f489"
+source = "git+https://github.com/wasmerio/wasmer.git?rev=e4101323e18d07c7f8367f1de1cec7cd5eff1b74#e4101323e18d07c7f8367f1de1cec7cd5eff1b74"
 dependencies = [
  "async-trait",
  "bytes",
@@ -4700,7 +4700,7 @@ dependencies = [
 [[package]]
 name = "virtual-net"
 version = "0.704.0"
-source = "git+https://github.com/wasmerio/wasmer.git?rev=06f1e8dca774f313d1e4a86e7bd9324a8fd0f489#06f1e8dca774f313d1e4a86e7bd9324a8fd0f489"
+source = "git+https://github.com/wasmerio/wasmer.git?rev=e4101323e18d07c7f8367f1de1cec7cd5eff1b74#e4101323e18d07c7f8367f1de1cec7cd5eff1b74"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4976,7 +4976,7 @@ dependencies = [
 [[package]]
 name = "wasmer"
 version = "7.4.0"
-source = "git+https://github.com/wasmerio/wasmer.git?rev=06f1e8dca774f313d1e4a86e7bd9324a8fd0f489#06f1e8dca774f313d1e4a86e7bd9324a8fd0f489"
+source = "git+https://github.com/wasmerio/wasmer.git?rev=e4101323e18d07c7f8367f1de1cec7cd5eff1b74#e4101323e18d07c7f8367f1de1cec7cd5eff1b74"
 dependencies = [
  "bindgen",
  "bytes",
@@ -5014,7 +5014,7 @@ dependencies = [
 [[package]]
 name = "wasmer-c-api-imports"
 version = "7.4.0"
-source = "git+https://github.com/wasmerio/wasmer.git?rev=06f1e8dca774f313d1e4a86e7bd9324a8fd0f489#06f1e8dca774f313d1e4a86e7bd9324a8fd0f489"
+source = "git+https://github.com/wasmerio/wasmer.git?rev=e4101323e18d07c7f8367f1de1cec7cd5eff1b74#e4101323e18d07c7f8367f1de1cec7cd5eff1b74"
 dependencies = [
  "anyhow",
  "bytes",
@@ -5027,7 +5027,7 @@ dependencies = [
 [[package]]
 name = "wasmer-compiler"
 version = "7.4.0"
-source = "git+https://github.com/wasmerio/wasmer.git?rev=06f1e8dca774f313d1e4a86e7bd9324a8fd0f489#06f1e8dca774f313d1e4a86e7bd9324a8fd0f489"
+source = "git+https://github.com/wasmerio/wasmer.git?rev=e4101323e18d07c7f8367f1de1cec7cd5eff1b74#e4101323e18d07c7f8367f1de1cec7cd5eff1b74"
 dependencies = [
  "addr2line 0.27.1",
  "backtrace",
@@ -5066,7 +5066,7 @@ dependencies = [
 [[package]]
 name = "wasmer-compiler-cranelift"
 version = "7.4.0"
-source = "git+https://github.com/wasmerio/wasmer.git?rev=06f1e8dca774f313d1e4a86e7bd9324a8fd0f489#06f1e8dca774f313d1e4a86e7bd9324a8fd0f489"
+source = "git+https://github.com/wasmerio/wasmer.git?rev=e4101323e18d07c7f8367f1de1cec7cd5eff1b74#e4101323e18d07c7f8367f1de1cec7cd5eff1b74"
 dependencies = [
  "cranelift-codegen",
  "cranelift-entity",
@@ -5088,7 +5088,7 @@ dependencies = [
 [[package]]
 name = "wasmer-config"
 version = "0.704.0"
-source = "git+https://github.com/wasmerio/wasmer.git?rev=06f1e8dca774f313d1e4a86e7bd9324a8fd0f489#06f1e8dca774f313d1e4a86e7bd9324a8fd0f489"
+source = "git+https://github.com/wasmerio/wasmer.git?rev=e4101323e18d07c7f8367f1de1cec7cd5eff1b74#e4101323e18d07c7f8367f1de1cec7cd5eff1b74"
 dependencies = [
  "anyhow",
  "bytesize",
@@ -5110,7 +5110,7 @@ dependencies = [
 [[package]]
 name = "wasmer-derive"
 version = "7.4.0"
-source = "git+https://github.com/wasmerio/wasmer.git?rev=06f1e8dca774f313d1e4a86e7bd9324a8fd0f489#06f1e8dca774f313d1e4a86e7bd9324a8fd0f489"
+source = "git+https://github.com/wasmerio/wasmer.git?rev=e4101323e18d07c7f8367f1de1cec7cd5eff1b74#e4101323e18d07c7f8367f1de1cec7cd5eff1b74"
 dependencies = [
  "proc-macro-error2",
  "proc-macro2",
@@ -5121,7 +5121,7 @@ dependencies = [
 [[package]]
 name = "wasmer-journal"
 version = "0.704.0"
-source = "git+https://github.com/wasmerio/wasmer.git?rev=06f1e8dca774f313d1e4a86e7bd9324a8fd0f489#06f1e8dca774f313d1e4a86e7bd9324a8fd0f489"
+source = "git+https://github.com/wasmerio/wasmer.git?rev=e4101323e18d07c7f8367f1de1cec7cd5eff1b74#e4101323e18d07c7f8367f1de1cec7cd5eff1b74"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -5148,7 +5148,7 @@ dependencies = [
 [[package]]
 name = "wasmer-napi"
 version = "0.704.0"
-source = "git+https://github.com/wasmerio/wasmer.git?rev=06f1e8dca774f313d1e4a86e7bd9324a8fd0f489#06f1e8dca774f313d1e4a86e7bd9324a8fd0f489"
+source = "git+https://github.com/wasmerio/wasmer.git?rev=e4101323e18d07c7f8367f1de1cec7cd5eff1b74#e4101323e18d07c7f8367f1de1cec7cd5eff1b74"
 dependencies = [
  "anyhow",
  "cc",
@@ -5167,7 +5167,7 @@ dependencies = [
 [[package]]
 name = "wasmer-package"
 version = "0.704.0"
-source = "git+https://github.com/wasmerio/wasmer.git?rev=06f1e8dca774f313d1e4a86e7bd9324a8fd0f489#06f1e8dca774f313d1e4a86e7bd9324a8fd0f489"
+source = "git+https://github.com/wasmerio/wasmer.git?rev=e4101323e18d07c7f8367f1de1cec7cd5eff1b74#e4101323e18d07c7f8367f1de1cec7cd5eff1b74"
 dependencies = [
  "anyhow",
  "bytes",
@@ -5275,7 +5275,7 @@ dependencies = [
 [[package]]
 name = "wasmer-types"
 version = "7.4.0"
-source = "git+https://github.com/wasmerio/wasmer.git?rev=06f1e8dca774f313d1e4a86e7bd9324a8fd0f489#06f1e8dca774f313d1e4a86e7bd9324a8fd0f489"
+source = "git+https://github.com/wasmerio/wasmer.git?rev=e4101323e18d07c7f8367f1de1cec7cd5eff1b74#e4101323e18d07c7f8367f1de1cec7cd5eff1b74"
 dependencies = [
  "bytecheck",
  "crc32fast",
@@ -5297,7 +5297,7 @@ dependencies = [
 [[package]]
 name = "wasmer-vm"
 version = "7.4.0"
-source = "git+https://github.com/wasmerio/wasmer.git?rev=06f1e8dca774f313d1e4a86e7bd9324a8fd0f489#06f1e8dca774f313d1e4a86e7bd9324a8fd0f489"
+source = "git+https://github.com/wasmerio/wasmer.git?rev=e4101323e18d07c7f8367f1de1cec7cd5eff1b74#e4101323e18d07c7f8367f1de1cec7cd5eff1b74"
 dependencies = [
  "backtrace",
  "bytesize",
@@ -5326,7 +5326,7 @@ dependencies = [
 [[package]]
 name = "wasmer-wasix"
 version = "0.704.0"
-source = "git+https://github.com/wasmerio/wasmer.git?rev=06f1e8dca774f313d1e4a86e7bd9324a8fd0f489#06f1e8dca774f313d1e4a86e7bd9324a8fd0f489"
+source = "git+https://github.com/wasmerio/wasmer.git?rev=e4101323e18d07c7f8367f1de1cec7cd5eff1b74#e4101323e18d07c7f8367f1de1cec7cd5eff1b74"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -5408,7 +5408,7 @@ dependencies = [
 [[package]]
 name = "wasmer-wasix-types"
 version = "0.704.0"
-source = "git+https://github.com/wasmerio/wasmer.git?rev=06f1e8dca774f313d1e4a86e7bd9324a8fd0f489#06f1e8dca774f313d1e4a86e7bd9324a8fd0f489"
+source = "git+https://github.com/wasmerio/wasmer.git?rev=e4101323e18d07c7f8367f1de1cec7cd5eff1b74#e4101323e18d07c7f8367f1de1cec7cd5eff1b74"
 dependencies = [
  "anyhow",
  "bitflags 2.13.1",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,14 +13,14 @@ exclude = [
 resolver = "2"
 
 [patch.crates-io]
-virtual-fs = { git = "https://github.com/wasmerio/wasmer.git", rev = "06f1e8dca774f313d1e4a86e7bd9324a8fd0f489" }
-virtual-mio = { git = "https://github.com/wasmerio/wasmer.git", rev = "06f1e8dca774f313d1e4a86e7bd9324a8fd0f489" }
-virtual-net = { git = "https://github.com/wasmerio/wasmer.git", rev = "06f1e8dca774f313d1e4a86e7bd9324a8fd0f489" }
-wasmer = { git = "https://github.com/wasmerio/wasmer.git", rev = "06f1e8dca774f313d1e4a86e7bd9324a8fd0f489" }
-wasmer-c-api-imports = { git = "https://github.com/wasmerio/wasmer.git", rev = "06f1e8dca774f313d1e4a86e7bd9324a8fd0f489" }
-wasmer-config = { git = "https://github.com/wasmerio/wasmer.git", rev = "06f1e8dca774f313d1e4a86e7bd9324a8fd0f489" }
-wasmer-napi = { git = "https://github.com/wasmerio/wasmer.git", rev = "06f1e8dca774f313d1e4a86e7bd9324a8fd0f489" }
-wasmer-package = { git = "https://github.com/wasmerio/wasmer.git", rev = "06f1e8dca774f313d1e4a86e7bd9324a8fd0f489" }
-wasmer-types = { git = "https://github.com/wasmerio/wasmer.git", rev = "06f1e8dca774f313d1e4a86e7bd9324a8fd0f489" }
-wasmer-wasix = { git = "https://github.com/wasmerio/wasmer.git", rev = "06f1e8dca774f313d1e4a86e7bd9324a8fd0f489" }
-wasmer-wasix-types = { git = "https://github.com/wasmerio/wasmer.git", rev = "06f1e8dca774f313d1e4a86e7bd9324a8fd0f489" }
+virtual-fs = { git = "https://github.com/wasmerio/wasmer.git", rev = "e4101323e18d07c7f8367f1de1cec7cd5eff1b74" }
+virtual-mio = { git = "https://github.com/wasmerio/wasmer.git", rev = "e4101323e18d07c7f8367f1de1cec7cd5eff1b74" }
+virtual-net = { git = "https://github.com/wasmerio/wasmer.git", rev = "e4101323e18d07c7f8367f1de1cec7cd5eff1b74" }
+wasmer = { git = "https://github.com/wasmerio/wasmer.git", rev = "e4101323e18d07c7f8367f1de1cec7cd5eff1b74" }
+wasmer-c-api-imports = { git = "https://github.com/wasmerio/wasmer.git", rev = "e4101323e18d07c7f8367f1de1cec7cd5eff1b74" }
+wasmer-config = { git = "https://github.com/wasmerio/wasmer.git", rev = "e4101323e18d07c7f8367f1de1cec7cd5eff1b74" }
+wasmer-napi = { git = "https://github.com/wasmerio/wasmer.git", rev = "e4101323e18d07c7f8367f1de1cec7cd5eff1b74" }
+wasmer-package = { git = "https://github.com/wasmerio/wasmer.git", rev = "e4101323e18d07c7f8367f1de1cec7cd5eff1b74" }
+wasmer-types = { git = "https://github.com/wasmerio/wasmer.git", rev = "e4101323e18d07c7f8367f1de1cec7cd5eff1b74" }
+wasmer-wasix = { git = "https://github.com/wasmerio/wasmer.git", rev = "e4101323e18d07c7f8367f1de1cec7cd5eff1b74" }
+wasmer-wasix-types = { git = "https://github.com/wasmerio/wasmer.git", rev = "e4101323e18d07c7f8367f1de1cec7cd5eff1b74" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,14 +13,14 @@ exclude = [
 resolver = "2"
 
 [patch.crates-io]
-virtual-fs = { git = "https://github.com/wasmerio/wasmer.git", rev = "6a3731fa465efb32f4d9e9406f867a4e7aef497a" }
-virtual-mio = { git = "https://github.com/wasmerio/wasmer.git", rev = "6a3731fa465efb32f4d9e9406f867a4e7aef497a" }
-virtual-net = { git = "https://github.com/wasmerio/wasmer.git", rev = "6a3731fa465efb32f4d9e9406f867a4e7aef497a" }
-wasmer = { git = "https://github.com/wasmerio/wasmer.git", rev = "6a3731fa465efb32f4d9e9406f867a4e7aef497a" }
-wasmer-c-api-imports = { git = "https://github.com/wasmerio/wasmer.git", rev = "6a3731fa465efb32f4d9e9406f867a4e7aef497a" }
-wasmer-config = { git = "https://github.com/wasmerio/wasmer.git", rev = "6a3731fa465efb32f4d9e9406f867a4e7aef497a" }
-wasmer-napi = { git = "https://github.com/wasmerio/wasmer.git", rev = "6a3731fa465efb32f4d9e9406f867a4e7aef497a" }
-wasmer-package = { git = "https://github.com/wasmerio/wasmer.git", rev = "6a3731fa465efb32f4d9e9406f867a4e7aef497a" }
-wasmer-types = { git = "https://github.com/wasmerio/wasmer.git", rev = "6a3731fa465efb32f4d9e9406f867a4e7aef497a" }
-wasmer-wasix = { git = "https://github.com/wasmerio/wasmer.git", rev = "6a3731fa465efb32f4d9e9406f867a4e7aef497a" }
-wasmer-wasix-types = { git = "https://github.com/wasmerio/wasmer.git", rev = "6a3731fa465efb32f4d9e9406f867a4e7aef497a" }
+virtual-fs = { git = "https://github.com/wasmerio/wasmer.git", rev = "06f1e8dca774f313d1e4a86e7bd9324a8fd0f489" }
+virtual-mio = { git = "https://github.com/wasmerio/wasmer.git", rev = "06f1e8dca774f313d1e4a86e7bd9324a8fd0f489" }
+virtual-net = { git = "https://github.com/wasmerio/wasmer.git", rev = "06f1e8dca774f313d1e4a86e7bd9324a8fd0f489" }
+wasmer = { git = "https://github.com/wasmerio/wasmer.git", rev = "06f1e8dca774f313d1e4a86e7bd9324a8fd0f489" }
+wasmer-c-api-imports = { git = "https://github.com/wasmerio/wasmer.git", rev = "06f1e8dca774f313d1e4a86e7bd9324a8fd0f489" }
+wasmer-config = { git = "https://github.com/wasmerio/wasmer.git", rev = "06f1e8dca774f313d1e4a86e7bd9324a8fd0f489" }
+wasmer-napi = { git = "https://github.com/wasmerio/wasmer.git", rev = "06f1e8dca774f313d1e4a86e7bd9324a8fd0f489" }
+wasmer-package = { git = "https://github.com/wasmerio/wasmer.git", rev = "06f1e8dca774f313d1e4a86e7bd9324a8fd0f489" }
+wasmer-types = { git = "https://github.com/wasmerio/wasmer.git", rev = "06f1e8dca774f313d1e4a86e7bd9324a8fd0f489" }
+wasmer-wasix = { git = "https://github.com/wasmerio/wasmer.git", rev = "06f1e8dca774f313d1e4a86e7bd9324a8fd0f489" }
+wasmer-wasix-types = { git = "https://github.com/wasmerio/wasmer.git", rev = "06f1e8dca774f313d1e4a86e7bd9324a8fd0f489" }

--- a/python/README.md
+++ b/python/README.md
@@ -77,7 +77,7 @@ Network access is an explicit sandbox capability:
 
 ```python
 sandbox = await wasmer.sandboxes.create(
-    packages=["wasmer/edgejs-quickjs@0.1.0"],
+    packages=["wasmer/edgejs@0.2.0"],
     network="host",
 )
 ```

--- a/python/examples/edgejs_http.py
+++ b/python/examples/edgejs_http.py
@@ -40,7 +40,7 @@ async def main() -> None:
 
     async with Wasmer(output_bytes=256 * 1024) as wasmer:
         sandbox = await wasmer.sandboxes.create(
-            packages=["wasmer/edgejs-quickjs@0.1.0"],
+            packages=["wasmer/edgejs@0.2.0"],
             files={"server.js": SERVER_SOURCE.read_bytes()},
             env={"PORT": str(port)},
             network="host",

--- a/python/examples/multiple_runtimes.py
+++ b/python/examples/multiple_runtimes.py
@@ -8,7 +8,7 @@ async def main() -> None:
     sandbox = await wasmer.sandboxes.create(
         packages=[
             "python/python@=3.13.18",
-            "wasmer/edgejs-quickjs",
+            "wasmer/edgejs@0.2.0",
             "php/php-32",
         ]
     )

--- a/python/tests/test_edgejs_http.py
+++ b/python/tests/test_edgejs_http.py
@@ -19,9 +19,7 @@ class EdgeJsHttpTests(unittest.IsolatedAsyncioTestCase):
         sandbox = None
         process = None
         try:
-            edgejs = await client.packages.load(
-                "wasmer/edgejs-quickjs@0.1.0"
-            )
+            edgejs = await client.packages.load("wasmer/edgejs@0.2.0")
             sandbox = await client.sandboxes.create(
                 packages=[edgejs],
                 files={"server.js": SERVER_SOURCE.read_bytes()},

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -14,6 +14,11 @@ sys = [
   "wasmer/cranelift",
   "wasmer-wasix/sys-default",
 ]
+napi-v8 = [
+  "sys",
+  "dep:wasmer-napi",
+  "wasmer-napi/wasix",
+]
 js = [
   "dep:web-sys",
   "wasmer-wasix/js",
@@ -45,6 +50,7 @@ webc = { version = "=12.0.1", default-features = false, features = ["v3"] }
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 tokio = { version = "1.49", features = ["fs", "rt-multi-thread"] }
+wasmer-napi = { version = "=0.704.0", optional = true, default-features = false }
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 web-sys = { version = "0.3", features = ["Window"], optional = true }

--- a/rust/src/command.rs
+++ b/rust/src/command.rs
@@ -1,3 +1,5 @@
+#[cfg(feature = "napi-v8")]
+use std::borrow::Cow;
 use std::{
     collections::{BTreeMap, HashSet},
     path::PathBuf,
@@ -7,8 +9,10 @@ use std::{
 
 use bytes::Bytes;
 use tokio::io::AsyncWriteExt;
-#[cfg(all(target_arch = "wasm32", feature = "js"))]
+#[cfg(any(all(target_arch = "wasm32", feature = "js"), feature = "napi-v8"))]
 use wasmer_wasix::bin_factory::BinaryPackageCommand;
+#[cfg(feature = "napi-v8")]
+use wasmer_wasix::runtime::ModuleInput;
 use wasmer_wasix::{
     Runtime,
     bin_factory::spawn_exec,
@@ -347,6 +351,8 @@ impl Command {
             .ok_or_else(|| Error::CommandNotFound {
                 command: command_name.clone(),
             })?;
+        #[cfg(feature = "napi-v8")]
+        configure_wasi_runner_for_napi(runtime.as_ref(), binary_command, &mut runner).await?;
         #[cfg(all(target_arch = "wasm32", feature = "js"))]
         precompile_browser_command(runtime.as_ref(), binary_command).await?;
         let wasi = binary_command
@@ -591,6 +597,28 @@ fn tolerate_early_exit(result: std::io::Result<()>) -> std::io::Result<()> {
         }
         other => other,
     }
+}
+
+#[cfg(feature = "napi-v8")]
+async fn configure_wasi_runner_for_napi(
+    runtime: &(dyn Runtime + Send + Sync),
+    command: &BinaryPackageCommand,
+    runner: &mut WasiRunner,
+) -> Result<()> {
+    let module = runtime
+        .resolve_module(ModuleInput::Command(Cow::Borrowed(command)), None, None)
+        .await
+        .map_err(|error| Error::Execution {
+            message: format!("unable to compile command for N-API detection: {error:#}"),
+        })?;
+    let (napi_version, napi_extension_version) = wasmer_napi::module_needs_napi(&module);
+    if napi_version.is_some() || napi_extension_version.is_some() {
+        runner
+            .capabilities_mut()
+            .threading
+            .enable_asynchronous_threading = false;
+    }
+    Ok(())
 }
 
 #[cfg(feature = "sys")]

--- a/rust/src/sandbox.rs
+++ b/rust/src/sandbox.rs
@@ -491,7 +491,10 @@ fn build_sandbox_runtime(
     let runtime: Arc<dyn Runtime + Send + Sync> =
         Arc::new(OverriddenRuntime::new(runtime).with_instantiation_hook(hooks));
 
-    #[cfg(all(target_arch = "wasm32", feature = "js-napi"))]
+    #[cfg(any(
+        all(target_arch = "wasm32", feature = "js-napi"),
+        all(not(target_arch = "wasm32"), feature = "napi-v8")
+    ))]
     let runtime: Arc<dyn Runtime + Send + Sync> = Arc::new(
         OverriddenRuntime::new(runtime)
             // This hook returns no imports for packages that do not use N-API.
@@ -501,7 +504,13 @@ fn build_sandbox_runtime(
     runtime
 }
 
-#[cfg(all(test, target_arch = "wasm32", feature = "js-napi"))]
+#[cfg(all(
+    test,
+    any(
+        all(target_arch = "wasm32", feature = "js-napi"),
+        all(not(target_arch = "wasm32"), feature = "napi-v8")
+    )
+))]
 mod napi_hook_tests {
     use wasmer_wasix::runtime::InstantiationHook;
 

--- a/rust/uniffi/Cargo.toml
+++ b/rust/uniffi/Cargo.toml
@@ -21,7 +21,7 @@ bindgen-cli = ["uniffi/cli"]
 [dependencies]
 tokio = { version = "1.49", features = ["io-util", "rt-multi-thread", "sync"] }
 uniffi = "0.32.0"
-wasmer-sdk = { path = "..", version = "=0.1.0" }
+wasmer-sdk = { path = "..", version = "=0.1.0", features = ["napi-v8"] }
 
 [dev-dependencies]
 futures = "0.3"


### PR DESCRIPTION
## Summary

- enable the native Wasmer N-API runtime hooks in the Python UniFFI build
- detect N-API modules before execution and disable conflicting WASIX asynchronous threading
- update Python examples and integration coverage to use wasmer/edgejs@0.2.0

## Validation

- cargo check --locked -p wasmer-sdk-uniffi --features bindgen-cli
- cargo fmt --all -- --check
- cargo clippy --locked -p wasmer-sdk-uniffi --features bindgen-cli -- -D warnings
- cargo test --locked -p wasmer-sdk --features napi-v8 napi_runtime_hooks_implement_the_wasix_hook_contract
- python3 python/scripts/build.py
- PYTHONPATH=python/src python3 -m unittest discover -s python/tests -v (10 passed, 2 skipped)