### PR TITLE
fix(python): support AArch64 C char ABI

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4047,7 +4047,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
 dependencies = [
  "fastrand",
- "getrandom 0.3.4",
+ "getrandom 0.4.3",
  "once_cell",
  "rustix",
  "windows-sys 0.61.2",
@@ -4656,7 +4656,7 @@ checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 [[package]]
 name = "virtual-fs"
 version = "0.704.0"
-source = "git+https://github.com/wasmerio/wasmer.git?rev=e4101323e18d07c7f8367f1de1cec7cd5eff1b74#e4101323e18d07c7f8367f1de1cec7cd5eff1b74"
+source = "git+https://github.com/wasmerio/wasmer.git?rev=76df91bb48b887ef6c7bae8d8e5bb8d09a385ffe#76df91bb48b887ef6c7bae8d8e5bb8d09a385ffe"
 dependencies = [
  "async-trait",
  "bytes",
@@ -4684,7 +4684,7 @@ dependencies = [
 [[package]]
 name = "virtual-mio"
 version = "0.704.0"
-source = "git+https://github.com/wasmerio/wasmer.git?rev=e4101323e18d07c7f8367f1de1cec7cd5eff1b74#e4101323e18d07c7f8367f1de1cec7cd5eff1b74"
+source = "git+https://github.com/wasmerio/wasmer.git?rev=76df91bb48b887ef6c7bae8d8e5bb8d09a385ffe#76df91bb48b887ef6c7bae8d8e5bb8d09a385ffe"
 dependencies = [
  "async-trait",
  "bytes",
@@ -4700,7 +4700,7 @@ dependencies = [
 [[package]]
 name = "virtual-net"
 version = "0.704.0"
-source = "git+https://github.com/wasmerio/wasmer.git?rev=e4101323e18d07c7f8367f1de1cec7cd5eff1b74#e4101323e18d07c7f8367f1de1cec7cd5eff1b74"
+source = "git+https://github.com/wasmerio/wasmer.git?rev=76df91bb48b887ef6c7bae8d8e5bb8d09a385ffe#76df91bb48b887ef6c7bae8d8e5bb8d09a385ffe"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4976,7 +4976,7 @@ dependencies = [
 [[package]]
 name = "wasmer"
 version = "7.4.0"
-source = "git+https://github.com/wasmerio/wasmer.git?rev=e4101323e18d07c7f8367f1de1cec7cd5eff1b74#e4101323e18d07c7f8367f1de1cec7cd5eff1b74"
+source = "git+https://github.com/wasmerio/wasmer.git?rev=76df91bb48b887ef6c7bae8d8e5bb8d09a385ffe#76df91bb48b887ef6c7bae8d8e5bb8d09a385ffe"
 dependencies = [
  "bindgen",
  "bytes",
@@ -5014,7 +5014,7 @@ dependencies = [
 [[package]]
 name = "wasmer-c-api-imports"
 version = "7.4.0"
-source = "git+https://github.com/wasmerio/wasmer.git?rev=e4101323e18d07c7f8367f1de1cec7cd5eff1b74#e4101323e18d07c7f8367f1de1cec7cd5eff1b74"
+source = "git+https://github.com/wasmerio/wasmer.git?rev=76df91bb48b887ef6c7bae8d8e5bb8d09a385ffe#76df91bb48b887ef6c7bae8d8e5bb8d09a385ffe"
 dependencies = [
  "anyhow",
  "bytes",
@@ -5027,7 +5027,7 @@ dependencies = [
 [[package]]
 name = "wasmer-compiler"
 version = "7.4.0"
-source = "git+https://github.com/wasmerio/wasmer.git?rev=e4101323e18d07c7f8367f1de1cec7cd5eff1b74#e4101323e18d07c7f8367f1de1cec7cd5eff1b74"
+source = "git+https://github.com/wasmerio/wasmer.git?rev=76df91bb48b887ef6c7bae8d8e5bb8d09a385ffe#76df91bb48b887ef6c7bae8d8e5bb8d09a385ffe"
 dependencies = [
  "addr2line 0.27.1",
  "backtrace",
@@ -5066,7 +5066,7 @@ dependencies = [
 [[package]]
 name = "wasmer-compiler-cranelift"
 version = "7.4.0"
-source = "git+https://github.com/wasmerio/wasmer.git?rev=e4101323e18d07c7f8367f1de1cec7cd5eff1b74#e4101323e18d07c7f8367f1de1cec7cd5eff1b74"
+source = "git+https://github.com/wasmerio/wasmer.git?rev=76df91bb48b887ef6c7bae8d8e5bb8d09a385ffe#76df91bb48b887ef6c7bae8d8e5bb8d09a385ffe"
 dependencies = [
  "cranelift-codegen",
  "cranelift-entity",
@@ -5088,7 +5088,7 @@ dependencies = [
 [[package]]
 name = "wasmer-config"
 version = "0.704.0"
-source = "git+https://github.com/wasmerio/wasmer.git?rev=e4101323e18d07c7f8367f1de1cec7cd5eff1b74#e4101323e18d07c7f8367f1de1cec7cd5eff1b74"
+source = "git+https://github.com/wasmerio/wasmer.git?rev=76df91bb48b887ef6c7bae8d8e5bb8d09a385ffe#76df91bb48b887ef6c7bae8d8e5bb8d09a385ffe"
 dependencies = [
  "anyhow",
  "bytesize",
@@ -5110,7 +5110,7 @@ dependencies = [
 [[package]]
 name = "wasmer-derive"
 version = "7.4.0"
-source = "git+https://github.com/wasmerio/wasmer.git?rev=e4101323e18d07c7f8367f1de1cec7cd5eff1b74#e4101323e18d07c7f8367f1de1cec7cd5eff1b74"
+source = "git+https://github.com/wasmerio/wasmer.git?rev=76df91bb48b887ef6c7bae8d8e5bb8d09a385ffe#76df91bb48b887ef6c7bae8d8e5bb8d09a385ffe"
 dependencies = [
  "proc-macro-error2",
  "proc-macro2",
@@ -5121,7 +5121,7 @@ dependencies = [
 [[package]]
 name = "wasmer-journal"
 version = "0.704.0"
-source = "git+https://github.com/wasmerio/wasmer.git?rev=e4101323e18d07c7f8367f1de1cec7cd5eff1b74#e4101323e18d07c7f8367f1de1cec7cd5eff1b74"
+source = "git+https://github.com/wasmerio/wasmer.git?rev=76df91bb48b887ef6c7bae8d8e5bb8d09a385ffe#76df91bb48b887ef6c7bae8d8e5bb8d09a385ffe"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -5148,7 +5148,7 @@ dependencies = [
 [[package]]
 name = "wasmer-napi"
 version = "0.704.0"
-source = "git+https://github.com/wasmerio/wasmer.git?rev=e4101323e18d07c7f8367f1de1cec7cd5eff1b74#e4101323e18d07c7f8367f1de1cec7cd5eff1b74"
+source = "git+https://github.com/wasmerio/wasmer.git?rev=76df91bb48b887ef6c7bae8d8e5bb8d09a385ffe#76df91bb48b887ef6c7bae8d8e5bb8d09a385ffe"
 dependencies = [
  "anyhow",
  "cc",
@@ -5167,7 +5167,7 @@ dependencies = [
 [[package]]
 name = "wasmer-package"
 version = "0.704.0"
-source = "git+https://github.com/wasmerio/wasmer.git?rev=e4101323e18d07c7f8367f1de1cec7cd5eff1b74#e4101323e18d07c7f8367f1de1cec7cd5eff1b74"
+source = "git+https://github.com/wasmerio/wasmer.git?rev=76df91bb48b887ef6c7bae8d8e5bb8d09a385ffe#76df91bb48b887ef6c7bae8d8e5bb8d09a385ffe"
 dependencies = [
  "anyhow",
  "bytes",
@@ -5275,7 +5275,7 @@ dependencies = [
 [[package]]
 name = "wasmer-types"
 version = "7.4.0"
-source = "git+https://github.com/wasmerio/wasmer.git?rev=e4101323e18d07c7f8367f1de1cec7cd5eff1b74#e4101323e18d07c7f8367f1de1cec7cd5eff1b74"
+source = "git+https://github.com/wasmerio/wasmer.git?rev=76df91bb48b887ef6c7bae8d8e5bb8d09a385ffe#76df91bb48b887ef6c7bae8d8e5bb8d09a385ffe"
 dependencies = [
  "bytecheck",
  "crc32fast",
@@ -5297,7 +5297,7 @@ dependencies = [
 [[package]]
 name = "wasmer-vm"
 version = "7.4.0"
-source = "git+https://github.com/wasmerio/wasmer.git?rev=e4101323e18d07c7f8367f1de1cec7cd5eff1b74#e4101323e18d07c7f8367f1de1cec7cd5eff1b74"
+source = "git+https://github.com/wasmerio/wasmer.git?rev=76df91bb48b887ef6c7bae8d8e5bb8d09a385ffe#76df91bb48b887ef6c7bae8d8e5bb8d09a385ffe"
 dependencies = [
  "backtrace",
  "bytesize",
@@ -5326,7 +5326,7 @@ dependencies = [
 [[package]]
 name = "wasmer-wasix"
 version = "0.704.0"
-source = "git+https://github.com/wasmerio/wasmer.git?rev=e4101323e18d07c7f8367f1de1cec7cd5eff1b74#e4101323e18d07c7f8367f1de1cec7cd5eff1b74"
+source = "git+https://github.com/wasmerio/wasmer.git?rev=76df91bb48b887ef6c7bae8d8e5bb8d09a385ffe#76df91bb48b887ef6c7bae8d8e5bb8d09a385ffe"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -5408,7 +5408,7 @@ dependencies = [
 [[package]]
 name = "wasmer-wasix-types"
 version = "0.704.0"
-source = "git+https://github.com/wasmerio/wasmer.git?rev=e4101323e18d07c7f8367f1de1cec7cd5eff1b74#e4101323e18d07c7f8367f1de1cec7cd5eff1b74"
+source = "git+https://github.com/wasmerio/wasmer.git?rev=76df91bb48b887ef6c7bae8d8e5bb8d09a385ffe#76df91bb48b887ef6c7bae8d8e5bb8d09a385ffe"
 dependencies = [
  "anyhow",
  "bitflags 2.13.1",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,14 +13,14 @@ exclude = [
 resolver = "2"
 
 [patch.crates-io]
-virtual-fs = { git = "https://github.com/wasmerio/wasmer.git", rev = "e4101323e18d07c7f8367f1de1cec7cd5eff1b74" }
-virtual-mio = { git = "https://github.com/wasmerio/wasmer.git", rev = "e4101323e18d07c7f8367f1de1cec7cd5eff1b74" }
-virtual-net = { git = "https://github.com/wasmerio/wasmer.git", rev = "e4101323e18d07c7f8367f1de1cec7cd5eff1b74" }
-wasmer = { git = "https://github.com/wasmerio/wasmer.git", rev = "e4101323e18d07c7f8367f1de1cec7cd5eff1b74" }
-wasmer-c-api-imports = { git = "https://github.com/wasmerio/wasmer.git", rev = "e4101323e18d07c7f8367f1de1cec7cd5eff1b74" }
-wasmer-config = { git = "https://github.com/wasmerio/wasmer.git", rev = "e4101323e18d07c7f8367f1de1cec7cd5eff1b74" }
-wasmer-napi = { git = "https://github.com/wasmerio/wasmer.git", rev = "e4101323e18d07c7f8367f1de1cec7cd5eff1b74" }
-wasmer-package = { git = "https://github.com/wasmerio/wasmer.git", rev = "e4101323e18d07c7f8367f1de1cec7cd5eff1b74" }
-wasmer-types = { git = "https://github.com/wasmerio/wasmer.git", rev = "e4101323e18d07c7f8367f1de1cec7cd5eff1b74" }
-wasmer-wasix = { git = "https://github.com/wasmerio/wasmer.git", rev = "e4101323e18d07c7f8367f1de1cec7cd5eff1b74" }
-wasmer-wasix-types = { git = "https://github.com/wasmerio/wasmer.git", rev = "e4101323e18d07c7f8367f1de1cec7cd5eff1b74" }
+virtual-fs = { git = "https://github.com/wasmerio/wasmer.git", rev = "76df91bb48b887ef6c7bae8d8e5bb8d09a385ffe" }
+virtual-mio = { git = "https://github.com/wasmerio/wasmer.git", rev = "76df91bb48b887ef6c7bae8d8e5bb8d09a385ffe" }
+virtual-net = { git = "https://github.com/wasmerio/wasmer.git", rev = "76df91bb48b887ef6c7bae8d8e5bb8d09a385ffe" }
+wasmer = { git = "https://github.com/wasmerio/wasmer.git", rev = "76df91bb48b887ef6c7bae8d8e5bb8d09a385ffe" }
+wasmer-c-api-imports = { git = "https://github.com/wasmerio/wasmer.git", rev = "76df91bb48b887ef6c7bae8d8e5bb8d09a385ffe" }
+wasmer-config = { git = "https://github.com/wasmerio/wasmer.git", rev = "76df91bb48b887ef6c7bae8d8e5bb8d09a385ffe" }
+wasmer-napi = { git = "https://github.com/wasmerio/wasmer.git", rev = "76df91bb48b887ef6c7bae8d8e5bb8d09a385ffe" }
+wasmer-package = { git = "https://github.com/wasmerio/wasmer.git", rev = "76df91bb48b887ef6c7bae8d8e5bb8d09a385ffe" }
+wasmer-types = { git = "https://github.com/wasmerio/wasmer.git", rev = "76df91bb48b887ef6c7bae8d8e5bb8d09a385ffe" }
+wasmer-wasix = { git = "https://github.com/wasmerio/wasmer.git", rev = "76df91bb48b887ef6c7bae8d8e5bb8d09a385ffe" }
+wasmer-wasix-types = { git = "https://github.com/wasmerio/wasmer.git", rev = "76df91bb48b887ef6c7bae8d8e5bb8d09a385ffe" }


### PR DESCRIPTION
Repin the Wasmer integration to the N-API bridge fix that uses platform-correct `c_char` pointers. This fixes the Python native build on Linux ARM64, where C `char` is unsigned.

Local validation:
- `cargo fmt --all -- --check`
- `cargo metadata --locked --format-version 1 --no-deps`
- `cargo check --locked -p wasmer-sdk-uniffi --features bindgen-cli --lib --bin uniffi-bindgen --release`

The release workflow will additionally build and test all four wheel targets, including the installed-wheel Edge.js smoke test.