### PR TITLE
fix(deps): use Python-safe V8 11.9.9 prebuilts

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4656,7 +4656,7 @@ checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 [[package]]
 name = "virtual-fs"
 version = "0.704.0"
-source = "git+https://github.com/wasmerio/wasmer.git?rev=f9753d4ac142ad8dcc69024b7f1786178a0e431d#f9753d4ac142ad8dcc69024b7f1786178a0e431d"
+source = "git+https://github.com/wasmerio/wasmer.git?rev=51f597fb99f7e4c562c7990e91c54831f8db8350#51f597fb99f7e4c562c7990e91c54831f8db8350"
 dependencies = [
  "async-trait",
  "bytes",
@@ -4684,7 +4684,7 @@ dependencies = [
 [[package]]
 name = "virtual-mio"
 version = "0.704.0"
-source = "git+https://github.com/wasmerio/wasmer.git?rev=f9753d4ac142ad8dcc69024b7f1786178a0e431d#f9753d4ac142ad8dcc69024b7f1786178a0e431d"
+source = "git+https://github.com/wasmerio/wasmer.git?rev=51f597fb99f7e4c562c7990e91c54831f8db8350#51f597fb99f7e4c562c7990e91c54831f8db8350"
 dependencies = [
  "async-trait",
  "bytes",
@@ -4700,7 +4700,7 @@ dependencies = [
 [[package]]
 name = "virtual-net"
 version = "0.704.0"
-source = "git+https://github.com/wasmerio/wasmer.git?rev=f9753d4ac142ad8dcc69024b7f1786178a0e431d#f9753d4ac142ad8dcc69024b7f1786178a0e431d"
+source = "git+https://github.com/wasmerio/wasmer.git?rev=51f597fb99f7e4c562c7990e91c54831f8db8350#51f597fb99f7e4c562c7990e91c54831f8db8350"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4976,7 +4976,7 @@ dependencies = [
 [[package]]
 name = "wasmer"
 version = "7.4.0"
-source = "git+https://github.com/wasmerio/wasmer.git?rev=f9753d4ac142ad8dcc69024b7f1786178a0e431d#f9753d4ac142ad8dcc69024b7f1786178a0e431d"
+source = "git+https://github.com/wasmerio/wasmer.git?rev=51f597fb99f7e4c562c7990e91c54831f8db8350#51f597fb99f7e4c562c7990e91c54831f8db8350"
 dependencies = [
  "bindgen",
  "bytes",
@@ -5014,7 +5014,7 @@ dependencies = [
 [[package]]
 name = "wasmer-c-api-imports"
 version = "7.4.0"
-source = "git+https://github.com/wasmerio/wasmer.git?rev=f9753d4ac142ad8dcc69024b7f1786178a0e431d#f9753d4ac142ad8dcc69024b7f1786178a0e431d"
+source = "git+https://github.com/wasmerio/wasmer.git?rev=51f597fb99f7e4c562c7990e91c54831f8db8350#51f597fb99f7e4c562c7990e91c54831f8db8350"
 dependencies = [
  "anyhow",
  "bytes",
@@ -5027,7 +5027,7 @@ dependencies = [
 [[package]]
 name = "wasmer-compiler"
 version = "7.4.0"
-source = "git+https://github.com/wasmerio/wasmer.git?rev=f9753d4ac142ad8dcc69024b7f1786178a0e431d#f9753d4ac142ad8dcc69024b7f1786178a0e431d"
+source = "git+https://github.com/wasmerio/wasmer.git?rev=51f597fb99f7e4c562c7990e91c54831f8db8350#51f597fb99f7e4c562c7990e91c54831f8db8350"
 dependencies = [
  "addr2line 0.27.1",
  "backtrace",
@@ -5066,7 +5066,7 @@ dependencies = [
 [[package]]
 name = "wasmer-compiler-cranelift"
 version = "7.4.0"
-source = "git+https://github.com/wasmerio/wasmer.git?rev=f9753d4ac142ad8dcc69024b7f1786178a0e431d#f9753d4ac142ad8dcc69024b7f1786178a0e431d"
+source = "git+https://github.com/wasmerio/wasmer.git?rev=51f597fb99f7e4c562c7990e91c54831f8db8350#51f597fb99f7e4c562c7990e91c54831f8db8350"
 dependencies = [
  "cranelift-codegen",
  "cranelift-entity",
@@ -5088,7 +5088,7 @@ dependencies = [
 [[package]]
 name = "wasmer-config"
 version = "0.704.0"
-source = "git+https://github.com/wasmerio/wasmer.git?rev=f9753d4ac142ad8dcc69024b7f1786178a0e431d#f9753d4ac142ad8dcc69024b7f1786178a0e431d"
+source = "git+https://github.com/wasmerio/wasmer.git?rev=51f597fb99f7e4c562c7990e91c54831f8db8350#51f597fb99f7e4c562c7990e91c54831f8db8350"
 dependencies = [
  "anyhow",
  "bytesize",
@@ -5110,7 +5110,7 @@ dependencies = [
 [[package]]
 name = "wasmer-derive"
 version = "7.4.0"
-source = "git+https://github.com/wasmerio/wasmer.git?rev=f9753d4ac142ad8dcc69024b7f1786178a0e431d#f9753d4ac142ad8dcc69024b7f1786178a0e431d"
+source = "git+https://github.com/wasmerio/wasmer.git?rev=51f597fb99f7e4c562c7990e91c54831f8db8350#51f597fb99f7e4c562c7990e91c54831f8db8350"
 dependencies = [
  "proc-macro-error2",
  "proc-macro2",
@@ -5121,7 +5121,7 @@ dependencies = [
 [[package]]
 name = "wasmer-journal"
 version = "0.704.0"
-source = "git+https://github.com/wasmerio/wasmer.git?rev=f9753d4ac142ad8dcc69024b7f1786178a0e431d#f9753d4ac142ad8dcc69024b7f1786178a0e431d"
+source = "git+https://github.com/wasmerio/wasmer.git?rev=51f597fb99f7e4c562c7990e91c54831f8db8350#51f597fb99f7e4c562c7990e91c54831f8db8350"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -5148,7 +5148,7 @@ dependencies = [
 [[package]]
 name = "wasmer-napi"
 version = "0.704.0"
-source = "git+https://github.com/wasmerio/wasmer.git?rev=f9753d4ac142ad8dcc69024b7f1786178a0e431d#f9753d4ac142ad8dcc69024b7f1786178a0e431d"
+source = "git+https://github.com/wasmerio/wasmer.git?rev=51f597fb99f7e4c562c7990e91c54831f8db8350#51f597fb99f7e4c562c7990e91c54831f8db8350"
 dependencies = [
  "anyhow",
  "cc",
@@ -5167,7 +5167,7 @@ dependencies = [
 [[package]]
 name = "wasmer-package"
 version = "0.704.0"
-source = "git+https://github.com/wasmerio/wasmer.git?rev=f9753d4ac142ad8dcc69024b7f1786178a0e431d#f9753d4ac142ad8dcc69024b7f1786178a0e431d"
+source = "git+https://github.com/wasmerio/wasmer.git?rev=51f597fb99f7e4c562c7990e91c54831f8db8350#51f597fb99f7e4c562c7990e91c54831f8db8350"
 dependencies = [
  "anyhow",
  "bytes",
@@ -5275,7 +5275,7 @@ dependencies = [
 [[package]]
 name = "wasmer-types"
 version = "7.4.0"
-source = "git+https://github.com/wasmerio/wasmer.git?rev=f9753d4ac142ad8dcc69024b7f1786178a0e431d#f9753d4ac142ad8dcc69024b7f1786178a0e431d"
+source = "git+https://github.com/wasmerio/wasmer.git?rev=51f597fb99f7e4c562c7990e91c54831f8db8350#51f597fb99f7e4c562c7990e91c54831f8db8350"
 dependencies = [
  "bytecheck",
  "crc32fast",
@@ -5297,7 +5297,7 @@ dependencies = [
 [[package]]
 name = "wasmer-vm"
 version = "7.4.0"
-source = "git+https://github.com/wasmerio/wasmer.git?rev=f9753d4ac142ad8dcc69024b7f1786178a0e431d#f9753d4ac142ad8dcc69024b7f1786178a0e431d"
+source = "git+https://github.com/wasmerio/wasmer.git?rev=51f597fb99f7e4c562c7990e91c54831f8db8350#51f597fb99f7e4c562c7990e91c54831f8db8350"
 dependencies = [
  "backtrace",
  "bytesize",
@@ -5326,7 +5326,7 @@ dependencies = [
 [[package]]
 name = "wasmer-wasix"
 version = "0.704.0"
-source = "git+https://github.com/wasmerio/wasmer.git?rev=f9753d4ac142ad8dcc69024b7f1786178a0e431d#f9753d4ac142ad8dcc69024b7f1786178a0e431d"
+source = "git+https://github.com/wasmerio/wasmer.git?rev=51f597fb99f7e4c562c7990e91c54831f8db8350#51f597fb99f7e4c562c7990e91c54831f8db8350"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -5408,7 +5408,7 @@ dependencies = [
 [[package]]
 name = "wasmer-wasix-types"
 version = "0.704.0"
-source = "git+https://github.com/wasmerio/wasmer.git?rev=f9753d4ac142ad8dcc69024b7f1786178a0e431d#f9753d4ac142ad8dcc69024b7f1786178a0e431d"
+source = "git+https://github.com/wasmerio/wasmer.git?rev=51f597fb99f7e4c562c7990e91c54831f8db8350#51f597fb99f7e4c562c7990e91c54831f8db8350"
 dependencies = [
  "anyhow",
  "bitflags 2.13.1",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,14 +13,14 @@ exclude = [
 resolver = "2"
 
 [patch.crates-io]
-virtual-fs = { git = "https://github.com/wasmerio/wasmer.git", rev = "f9753d4ac142ad8dcc69024b7f1786178a0e431d" }
-virtual-mio = { git = "https://github.com/wasmerio/wasmer.git", rev = "f9753d4ac142ad8dcc69024b7f1786178a0e431d" }
-virtual-net = { git = "https://github.com/wasmerio/wasmer.git", rev = "f9753d4ac142ad8dcc69024b7f1786178a0e431d" }
-wasmer = { git = "https://github.com/wasmerio/wasmer.git", rev = "f9753d4ac142ad8dcc69024b7f1786178a0e431d" }
-wasmer-c-api-imports = { git = "https://github.com/wasmerio/wasmer.git", rev = "f9753d4ac142ad8dcc69024b7f1786178a0e431d" }
-wasmer-config = { git = "https://github.com/wasmerio/wasmer.git", rev = "f9753d4ac142ad8dcc69024b7f1786178a0e431d" }
-wasmer-napi = { git = "https://github.com/wasmerio/wasmer.git", rev = "f9753d4ac142ad8dcc69024b7f1786178a0e431d" }
-wasmer-package = { git = "https://github.com/wasmerio/wasmer.git", rev = "f9753d4ac142ad8dcc69024b7f1786178a0e431d" }
-wasmer-types = { git = "https://github.com/wasmerio/wasmer.git", rev = "f9753d4ac142ad8dcc69024b7f1786178a0e431d" }
-wasmer-wasix = { git = "https://github.com/wasmerio/wasmer.git", rev = "f9753d4ac142ad8dcc69024b7f1786178a0e431d" }
-wasmer-wasix-types = { git = "https://github.com/wasmerio/wasmer.git", rev = "f9753d4ac142ad8dcc69024b7f1786178a0e431d" }
+virtual-fs = { git = "https://github.com/wasmerio/wasmer.git", rev = "51f597fb99f7e4c562c7990e91c54831f8db8350" }
+virtual-mio = { git = "https://github.com/wasmerio/wasmer.git", rev = "51f597fb99f7e4c562c7990e91c54831f8db8350" }
+virtual-net = { git = "https://github.com/wasmerio/wasmer.git", rev = "51f597fb99f7e4c562c7990e91c54831f8db8350" }
+wasmer = { git = "https://github.com/wasmerio/wasmer.git", rev = "51f597fb99f7e4c562c7990e91c54831f8db8350" }
+wasmer-c-api-imports = { git = "https://github.com/wasmerio/wasmer.git", rev = "51f597fb99f7e4c562c7990e91c54831f8db8350" }
+wasmer-config = { git = "https://github.com/wasmerio/wasmer.git", rev = "51f597fb99f7e4c562c7990e91c54831f8db8350" }
+wasmer-napi = { git = "https://github.com/wasmerio/wasmer.git", rev = "51f597fb99f7e4c562c7990e91c54831f8db8350" }
+wasmer-package = { git = "https://github.com/wasmerio/wasmer.git", rev = "51f597fb99f7e4c562c7990e91c54831f8db8350" }
+wasmer-types = { git = "https://github.com/wasmerio/wasmer.git", rev = "51f597fb99f7e4c562c7990e91c54831f8db8350" }
+wasmer-wasix = { git = "https://github.com/wasmerio/wasmer.git", rev = "51f597fb99f7e4c562c7990e91c54831f8db8350" }
+wasmer-wasix-types = { git = "https://github.com/wasmerio/wasmer.git", rev = "51f597fb99f7e4c562c7990e91c54831f8db8350" }


### PR DESCRIPTION
## Summary

Consume [V8 custom build 11.9.9](https://github.com/wasmerio/v8-custom-builds/releases/tag/11.9.9) through the updated Wasmer/N-API dependency stack, including the Linux TLS and ARM64 compatibility fixes needed when embedding V8 in Python extensions.

- Pin all Wasmer workspace patches and lockfile entries to `51f597fb99f7e4c562c7990e91c54831f8db8350` on wasmerio/wasmer#6956.
- Align `packages/napi` with Wasmer's `lib/napi` at `38834f059fea9df3585e2d76d31c255fa13f5dc9`, merged into N-API main through wasmerio/napi#72.
- Keep the simplified SDK worker transport from #484 unchanged. This PR changes only the manifest, lockfile, and N-API submodule pointer; no public API or package-version changes.

The matching EdgeJS N-API/Makefile/Nix update is merged into main via wasmerio/edgejs#152. The SDK continues to use the existing EdgeJS registry package; the native V8 provider comes from the pinned Wasmer/N-API build.

N-API now selects 11.9.9 consistently in Cargo/CMake/native-test consumers and links `libatomic` on Linux ARM64. The release uses library-safe Linux TLS and a manylinux 2.28 ARM64 toolchain. `11.9.9` is the custom-build release tag, not the upstream V8 engine version.

## Validation

- Built the Python UniFFI shared library with `python3 python/scripts/build.py`, using the immutable Git pin and the actual 11.9.9 Cargo-selected archive (no local dependency or V8 overrides).
- Python runtime suite: 6 passed; Python-to-EdgeJS HTTP regression: 1 passed.
- `cargo test --locked -p wasmer-sdk --features napi-v8 --all-targets`: 27 passed.
- `npm run test:bindgen`: 3 serialization tests passed.
- Formatting and diff checks passed; the lockfile changes only Wasmer source revisions.

Upstream validation: all eight N-API CI jobs passed; the 93-test native N-API suite passed on macOS ARM64 and Ubuntu 22.04 ARM64. On Ubuntu 22.04 (glibc 2.35), a shared library linked to the actual 11.9.9 archive loaded via Python `ctypes.CDLL` and executed JavaScript. Archive digests matched the release metadata; the ARM64 archive contains neither local-exec TLS relocations nor `__isoc23_*` imports. Wasmer integration also passed 45 N-API library tests and 3 host-control tests on macOS; the Linux-only `/proc` worker-count test was not run there.

Python package tests used an isolated copy of the existing package cache. Full Python wheel builds across all release targets are not claimed by the local validation.

EdgeJS's standard Node compatibility lane passed 1,749/1,749. Its separate CTest run had one intermittent REPL-wrapper failure, reproduced with both the old and new V8 archives (3/30 vs. 2/30 failures); that pre-existing issue is documented upstream. EdgeJS remote CI was still running when the requested main merge completed.

Integrated and validated by Codex, an OpenAI coding agent, at the repository owner's request.
