### PR TITLE
fix(ci): expose npm trusted-publishing rejection details

### DIFF
--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -113,7 +113,7 @@ jobs:
           path: npm-package
 
       - name: Publish with npm trusted publishing
-        run: npm publish ./npm-package/*.tgz --access public
+        run: npm publish ./npm-package/*.tgz --access public --loglevel=verbose
 
   sync-wasmer-sh:
     name: Update wasmer-sh to the published SDK


### PR DESCRIPTION
## Summary

Enable npm's verbose diagnostic log on the trusted-publishing step. No package code, permissions, or authentication configuration changes.

The 0.12.0 tarball builds and tests successfully, but both automatic and direct workflow dispatches fail at publication with a generic E404. The saved npm trusted publisher was verified in the signed-in package settings: `wasmerio/wasmer-sdk`, `publish-npm.yml`, environment `npm`, and direct publishing allowed. These match the workflow exactly.

npm's OIDC helper catches token-exchange failures and logs the rejection reason only at verbose level before falling back to token authentication. This makes that diagnostic available in the job log; npm's helper does not log the returned credentials.

## Validation

- `actionlint .github/workflows/publish-npm.yml`
- `git diff --check`
- All package tests already passed for the unchanged 0.12.0 tarball; normal required PR CI remains enabled.
